### PR TITLE
Fix issue of using regex global flag

### DIFF
--- a/app/scripts.babel/preview.js
+++ b/app/scripts.babel/preview.js
@@ -133,13 +133,13 @@ var Preview = function(Profile, config) {
     },
     getStoryboardDetails: function(html) {
       var storyboard = null;
-      var getStoryboardRegExp = new RegExp('\"storyboard_spec\": ?\"(.*?)\"', 'g');
-      var storyboard_spec = getStoryboardRegExp.exec(html);
-
-      if (getStoryboardRegExp.test(html) && storyboard_spec[1]) {
+      var storyboardRegExp = new RegExp('\"storyboard_spec\": ?\"(.*?)\"');
+      if (storyboardRegExp.test(html)) {
+        var storyboard_spec = storyboardRegExp.exec(html);
         var result = storyboard_spec[1].split('|');
-        var baseURL = result.shift();
-        storyboard = new Storyboard(result.pop(), baseURL, i);
+        var baseUrl = result.shift();
+        var lastIndex = result.length - 1;
+        storyboard = new Storyboard(result[lastIndex], baseUrl, lastIndex);
       } else {
         storyboard = new NoPreview();
       }


### PR DESCRIPTION
### WTF

``` javascript
var reg = new RegEx(/te/, 'g');
reg.test('test'); // => true
reg.test('test'); // => false
```

Running the first time returns true, but the second time returns false
It was due to `reg.lastIndex` wasn't reset to `0`.

Oh gosh...
http://stackoverflow.com/questions/10229144/bug-with-regexp-in-javascript-when-do-global-search
