### PR TITLE
Calculate the correct number of row in the end frame

### DIFF
--- a/app/scripts.babel/storyboard.js
+++ b/app/scripts.babel/storyboard.js
@@ -79,7 +79,7 @@ Storyboard.prototype.getPosition = function() {
   console.log('getPosition', this.count);
   var row = this.row;
   if(this.maxPage === this.page() + 1) {
-    var rest = this.totalFrames - this.col * this.row * (this.page() + 1);
+    var rest = this.totalFrames % (this.col * this.row);
     row = Math.ceil(rest / this.col);
   }
   return {


### PR DESCRIPTION
The calculation of the last page of the preview was wrong.
