### PR TITLE
Hide the watched badge temporarily when hovering

### DIFF
--- a/app/styles.scss/preview.scss
+++ b/app/styles.scss/preview.scss
@@ -25,8 +25,17 @@ $enlarged-playlist-video-image-height: 118px;
 $enlarged-playlist-video-image-width: 160px;
 $enlarged-video-image-top-adjustment: -14px;
 $enlarged-video-image-top-reset: 0;
+
 .thumb-wrapper, .yt-thumb-clip, .yt-lockup-thumbnail, .ytp-videowall-still {
   &:hover {
+    .watched-badge {
+      display: none;
+    }
+
+    .watched .video-thumb {
+      opacity: 1;
+    }
+
     .no-preview{
       display: block;
     }


### PR DESCRIPTION
Hide the watched badge temporarily when hovering
### Before

<img width="215" alt="screen shot 2016-10-24 at 7 31 57 pm" src="https://cloud.githubusercontent.com/assets/719938/19667763/bf98a708-9a20-11e6-81c9-d27068affdcf.png">
### After

<img width="213" alt="screen shot 2016-10-24 at 7 33 52 pm" src="https://cloud.githubusercontent.com/assets/719938/19667778/d23adcaa-9a20-11e6-9ae5-8dd6fcb51639.png">
